### PR TITLE
fix(news-aggregator): parse limits strictly

### DIFF
--- a/mcp_modules/news-aggregator/index.js
+++ b/mcp_modules/news-aggregator/index.js
@@ -17,6 +17,7 @@ import {
   debugRSSFeed,
 } from './src/controller.js';
 import { newsAggregatorService } from './src/service.js';
+import { parsePositiveIntegerLimit } from './src/limit.js';
 
 /**
  * Register this module with the Hono app
@@ -455,8 +456,8 @@ export async function register(app) {
 
           // Apply limit if specified
           if (params.limit) {
-            limitNum = parseInt(params.limit, 10);
-            if (!isNaN(limitNum) && limitNum > 0) {
+            limitNum = parsePositiveIntegerLimit(params.limit);
+            if (limitNum) {
               allArticles = allArticles.slice(0, limitNum);
             }
           }

--- a/mcp_modules/news-aggregator/src/controller.js
+++ b/mcp_modules/news-aggregator/src/controller.js
@@ -6,6 +6,7 @@
 
 import { newsAggregatorService } from './service.js';
 import { logger } from '../../../src/utils/logger.js';
+import { parsePositiveIntegerLimit } from './limit.js';
 
 /**
  * Get news from RSS feeds
@@ -311,8 +312,8 @@ export async function searchNews(c) {
 
     // Apply limit if specified
     if (limit) {
-      const limitNum = parseInt(limit, 10);
-      if (!isNaN(limitNum) && limitNum > 0) {
+      const limitNum = parsePositiveIntegerLimit(limit);
+      if (limitNum) {
         allArticles = allArticles.slice(0, limitNum);
       }
     }

--- a/mcp_modules/news-aggregator/src/limit.js
+++ b/mcp_modules/news-aggregator/src/limit.js
@@ -1,0 +1,13 @@
+export function parsePositiveIntegerLimit(value) {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+
+  const normalized = String(value);
+
+  if (!/^[1-9]\d*$/.test(normalized)) {
+    return null;
+  }
+
+  return Number(normalized);
+}

--- a/mcp_modules/news-aggregator/test/controller.test.js
+++ b/mcp_modules/news-aggregator/test/controller.test.js
@@ -14,6 +14,7 @@ import {
   clearCache,
   getHealthStatus,
 } from '../src/controller.js';
+import { parsePositiveIntegerLimit } from '../src/limit.js';
 
 describe('NewsAggregatorController', () => {
   let mockContext;
@@ -246,8 +247,12 @@ describe('NewsAggregatorController', () => {
 
       await searchNews(mockContext);
 
-      expect(mockContext.json.calledWith({ error: 'Keywords parameter is required' }, 400)).to.be
-        .true;
+      expect(
+        mockContext.json.calledWith(
+          { error: 'Either keywords or tickers parameter is required' },
+          400
+        )
+      ).to.be.true;
     });
 
     it('should apply limit to search results', async () => {
@@ -271,8 +276,50 @@ describe('NewsAggregatorController', () => {
 
       await searchNews(mockContext);
 
-      // Verify that the response was called (we can't easily check the exact limit without more complex mocking)
-      expect(mockContext.json.called).to.be.true;
+      const response = mockContext.json.firstCall.args[0];
+      expect(response.articles).to.have.length(2);
+      expect(response.totalResults).to.equal(2);
+    });
+
+    it('should ignore malformed limit values', async () => {
+      const mockAggregatedResult = {
+        sources: [
+          {
+            source: 'Google News',
+            category: 'technology',
+            articles: [
+              { title: 'Article 1', publishedAt: '2024-01-01T12:00:00.000Z' },
+              { title: 'Article 2', publishedAt: '2024-01-01T11:00:00.000Z' },
+              { title: 'Article 3', publishedAt: '2024-01-01T10:00:00.000Z' },
+            ],
+          },
+        ],
+      };
+
+      mockContext.req.query.returns({ keywords: 'test', limit: '2abc' });
+      serviceStub.getAggregatedNews.resolves(mockAggregatedResult);
+      serviceStub.filterByKeywords.returns(mockAggregatedResult.sources[0].articles);
+
+      await searchNews(mockContext);
+
+      const response = mockContext.json.firstCall.args[0];
+      expect(response.articles).to.have.length(3);
+      expect(response.totalResults).to.equal(3);
+    });
+  });
+
+  describe('parsePositiveIntegerLimit', () => {
+    it('parses positive integer limits only', () => {
+      expect(parsePositiveIntegerLimit('2')).to.equal(2);
+      expect(parsePositiveIntegerLimit(3)).to.equal(3);
+    });
+
+    it('rejects malformed, zero, and decimal limits', () => {
+      expect(parsePositiveIntegerLimit('2abc')).to.equal(null);
+      expect(parsePositiveIntegerLimit('0')).to.equal(null);
+      expect(parsePositiveIntegerLimit('1.5')).to.equal(null);
+      expect(parsePositiveIntegerLimit('-1')).to.equal(null);
+      expect(parsePositiveIntegerLimit('')).to.equal(null);
     });
   });
 


### PR DESCRIPTION
## Summary
- add a shared strict positive-integer limit parser for news-aggregator
- use it in both the HTTP search endpoint and MCP tool endpoint
- add regression coverage so malformed values like 2abc no longer get treated as 2

## Tests
- corepack pnpm install --frozen-lockfile
- corepack pnpm install (inside mcp_modules/news-aggregator)
- corepack pnpm exec mocha --require=./test/setup.js mcp_modules/news-aggregator/test/controller.test.js
- git diff --check

Note: root eslint on the touched news-aggregator files still reports pre-existing indentation style errors across the module, so I did not reformat the module in this focused bug fix.