### PR TITLE
fix(weather): validate coordinates at API boundaries

### DIFF
--- a/mcp_modules/weather/index.js
+++ b/mcp_modules/weather/index.js
@@ -14,6 +14,7 @@ import {
   getSatelliteImage,
 } from './src/controller.js';
 import { weatherService } from './src/service.js';
+import { validateCoordinates } from './src/utils.js';
 
 /**
  * Register this module with the Hono app
@@ -98,6 +99,14 @@ export async function register(app) {
           },
           400
         );
+      }
+
+      if (hasCoordinates) {
+        try {
+          validateCoordinates(params.latitude, params.longitude);
+        } catch (error) {
+          return c.json({ error: error.message }, 400);
+        }
       }
 
       let result;

--- a/mcp_modules/weather/src/controller.js
+++ b/mcp_modules/weather/src/controller.js
@@ -5,6 +5,26 @@
  */
 
 import { weatherService } from './service.js';
+import { validateCoordinates } from './utils.js';
+
+function parseCoordinates(c) {
+  const rawLat = c.req.param('lat');
+  const rawLon = c.req.param('lon');
+  if (!rawLat?.trim() || !rawLon?.trim()) return null;
+
+  const lat = Number(rawLat);
+  const lon = Number(rawLon);
+  try {
+    validateCoordinates(lat, lon);
+    return { lat, lon };
+  } catch {
+    return null;
+  }
+}
+
+function invalidCoordinates(c) {
+  return c.json({ error: 'Invalid latitude or longitude parameters' }, 400);
+}
 
 /**
  * Get current weather conditions
@@ -13,12 +33,9 @@ import { weatherService } from './service.js';
  */
 export async function getCurrentWeather(c) {
   try {
-    const lat = parseFloat(c.req.param('lat'));
-    const lon = parseFloat(c.req.param('lon'));
-
-    if (isNaN(lat) || isNaN(lon)) {
-      return c.json({ error: 'Invalid latitude or longitude parameters' }, 400);
-    }
+    const coordinates = parseCoordinates(c);
+    if (!coordinates) return invalidCoordinates(c);
+    const { lat, lon } = coordinates;
 
     const weatherData = await weatherService.getCurrentWeather(lat, lon);
     return c.json(weatherData);
@@ -34,13 +51,10 @@ export async function getCurrentWeather(c) {
  */
 export async function getForecast(c) {
   try {
-    const lat = parseFloat(c.req.param('lat'));
-    const lon = parseFloat(c.req.param('lon'));
+    const coordinates = parseCoordinates(c);
+    if (!coordinates) return invalidCoordinates(c);
+    const { lat, lon } = coordinates;
     const days = parseInt(c.req.query('days')) || 5;
-
-    if (isNaN(lat) || isNaN(lon)) {
-      return c.json({ error: 'Invalid latitude or longitude parameters' }, 400);
-    }
 
     if (days < 1 || days > 7) {
       return c.json({ error: 'Days parameter must be between 1 and 7' }, 400);
@@ -60,12 +74,9 @@ export async function getForecast(c) {
  */
 export async function getWeatherAlerts(c) {
   try {
-    const lat = parseFloat(c.req.param('lat'));
-    const lon = parseFloat(c.req.param('lon'));
-
-    if (isNaN(lat) || isNaN(lon)) {
-      return c.json({ error: 'Invalid latitude or longitude parameters' }, 400);
-    }
+    const coordinates = parseCoordinates(c);
+    if (!coordinates) return invalidCoordinates(c);
+    const { lat, lon } = coordinates;
 
     const alertsData = await weatherService.getWeatherAlerts(lat, lon);
     return c.json(alertsData);
@@ -81,12 +92,9 @@ export async function getWeatherAlerts(c) {
  */
 export async function getRadarImage(c) {
   try {
-    const lat = parseFloat(c.req.param('lat'));
-    const lon = parseFloat(c.req.param('lon'));
-
-    if (isNaN(lat) || isNaN(lon)) {
-      return c.json({ error: 'Invalid latitude or longitude parameters' }, 400);
-    }
+    const coordinates = parseCoordinates(c);
+    if (!coordinates) return invalidCoordinates(c);
+    const { lat, lon } = coordinates;
 
     const radarData = await weatherService.getRadarImage(lat, lon);
     return c.json(radarData);
@@ -102,12 +110,9 @@ export async function getRadarImage(c) {
  */
 export async function getSatelliteImage(c) {
   try {
-    const lat = parseFloat(c.req.param('lat'));
-    const lon = parseFloat(c.req.param('lon'));
-
-    if (isNaN(lat) || isNaN(lon)) {
-      return c.json({ error: 'Invalid latitude or longitude parameters' }, 400);
-    }
+    const coordinates = parseCoordinates(c);
+    if (!coordinates) return invalidCoordinates(c);
+    const { lat, lon } = coordinates;
 
     const satelliteData = await weatherService.getSatelliteImage(lat, lon);
     return c.json(satelliteData);

--- a/mcp_modules/weather/src/utils.js
+++ b/mcp_modules/weather/src/utils.js
@@ -11,10 +11,10 @@
  * @throws {Error} If coordinates are invalid
  */
 export function validateCoordinates(latitude, longitude) {
-  if (typeof latitude !== 'number' || latitude < -90 || latitude > 90) {
+  if (!Number.isFinite(latitude) || latitude < -90 || latitude > 90) {
     throw new Error('Invalid latitude: must be a number between -90 and 90');
   }
-  if (typeof longitude !== 'number' || longitude < -180 || longitude > 180) {
+  if (!Number.isFinite(longitude) || longitude < -180 || longitude > 180) {
     throw new Error('Invalid longitude: must be a number between -180 and 180');
   }
 }

--- a/mcp_modules/weather/test/coordinate-validation.test.js
+++ b/mcp_modules/weather/test/coordinate-validation.test.js
@@ -1,0 +1,56 @@
+import { afterEach, before, describe, it } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { Hono } from 'hono';
+import { register } from '../index.js';
+import { weatherService } from '../src/service.js';
+
+describe('Weather coordinate validation', () => {
+  let app;
+
+  before(async () => {
+    app = new Hono();
+    await register(app);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('rejects partially numeric REST coordinates before calling the service', async () => {
+    const service = sinon.stub(weatherService, 'getCurrentWeather').resolves({});
+
+    const response = await app.request('/weather/current/40abc/-74');
+
+    expect(response.status).to.equal(400);
+    expect(await response.json()).to.deep.equal({
+      error: 'Invalid latitude or longitude parameters',
+    });
+    expect(service.called).to.be.false;
+  });
+
+  it('rejects out-of-range REST coordinates before calling the service', async () => {
+    const service = sinon.stub(weatherService, 'getWeatherAlerts').resolves({});
+
+    const response = await app.request('/weather/alerts/91/0');
+
+    expect(response.status).to.equal(400);
+    expect(service.called).to.be.false;
+  });
+
+  it('rejects out-of-range MCP tool coordinates before calling the service', async () => {
+    const service = sinon.stub(weatherService, 'getSatelliteImage').resolves({});
+
+    const response = await app.request('/tools/weather', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'satellite', latitude: 0, longitude: 181 }),
+    });
+
+    expect(response.status).to.equal(400);
+    expect(await response.json()).to.deep.equal({
+      error: 'Invalid longitude: must be a number between -180 and 180',
+    });
+    expect(service.called).to.be.false;
+  });
+});

--- a/mcp_modules/weather/test/weather.test.js
+++ b/mcp_modules/weather/test/weather.test.js
@@ -40,12 +40,14 @@ describe('Weather Module', () => {
       it('should reject invalid latitude', () => {
         expect(() => utils.validateCoordinates(91, 0)).to.throw('Invalid latitude');
         expect(() => utils.validateCoordinates(-91, 0)).to.throw('Invalid latitude');
+        expect(() => utils.validateCoordinates(NaN, 0)).to.throw('Invalid latitude');
         expect(() => utils.validateCoordinates('invalid', 0)).to.throw('Invalid latitude');
       });
 
       it('should reject invalid longitude', () => {
         expect(() => utils.validateCoordinates(0, 181)).to.throw('Invalid longitude');
         expect(() => utils.validateCoordinates(0, -181)).to.throw('Invalid longitude');
+        expect(() => utils.validateCoordinates(0, NaN)).to.throw('Invalid longitude');
         expect(() => utils.validateCoordinates(0, 'invalid')).to.throw('Invalid longitude');
       });
     });


### PR DESCRIPTION
## Summary
- parse REST latitude and longitude strictly so partial values such as `40abc` are rejected
- reject non-finite and out-of-range coordinates before weather services are called
- apply the same validation to the MCP weather tool endpoint
- add focused REST, MCP, and utility regression coverage

## Tests
- `pnpm --dir mcp_modules/weather test` (32 passing)
- targeted ESLint for Weather controller, utilities, and tests
- `git diff --check`

The root suite reaches 53 passing and 5 pending tests; two existing Module Loader assertions fail in the Windows environment and are unrelated to Weather.